### PR TITLE
fix: 중복확인 로직을 튜터 DB에서도 적용되게 오류 수정

### DIFF
--- a/src/main/java/com/sparta/spartascheduling/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spartascheduling/domain/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.sparta.spartascheduling.domain.auth.dto.request.SignupRequestDto;
 import com.sparta.spartascheduling.domain.auth.dto.response.SignupResponseDto;
 import com.sparta.spartascheduling.domain.manager.entity.Manager;
 import com.sparta.spartascheduling.domain.manager.repository.ManagerRepository;
+import com.sparta.spartascheduling.domain.tutor.repository.TutorRepository;
 import com.sparta.spartascheduling.domain.user.entity.User;
 import com.sparta.spartascheduling.domain.user.repository.UserRepository;
 
@@ -22,11 +23,12 @@ public class AuthService {
 	private final UserRepository userRepository;
 	private final ManagerRepository managerRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final TutorRepository tutorRepository;
 	//private final JwtUtil jwtUtil;
 
 	public SignupResponseDto signup(SignupRequestDto requestDto) {
 
-		if (userRepository.existsByEmail(requestDto.getEmail()) || managerRepository.existsByEmail(requestDto.getEmail())) {
+		if (userRepository.existsByEmail(requestDto.getEmail()) || managerRepository.existsByEmail(requestDto.getEmail()) || tutorRepository.existsByEmail(requestDto.getEmail())) {
 			throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
 		}
 

--- a/src/main/java/com/sparta/spartascheduling/domain/tutor/repository/TutorRepository.java
+++ b/src/main/java/com/sparta/spartascheduling/domain/tutor/repository/TutorRepository.java
@@ -4,4 +4,5 @@ import com.sparta.spartascheduling.domain.tutor.entity.Tutor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TutorRepository extends JpaRepository<Tutor, Long> {
+	boolean existsByEmail(String email);
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게 수정했나보다 무엇을 왜 수정했는지 설명해주세요. -->
회원가입 시 중복된 이메일이 있는지 확인하는 로직에서 튜터들의 이메일은 체크하지 않았던 오류를 수정했습니다.
<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).